### PR TITLE
Mapping improvements, including new I/O/KV for info_zombiespawn

### DIFF
--- a/mp/game/zombie_master_reborn/zombie_master_reborn.fgd
+++ b/mp/game/zombie_master_reborn/zombie_master_reborn.fgd
@@ -100,6 +100,41 @@
 	nodename(target_destination) : "Spawn Node/Volume" : "" : "Targetname of the first spawn node, if any, in the chain of spawn nodes. This may also be a spawn volume trigger."
 	
 	modelgroup(string) : "Model Group" : "" : "Leave empty to use default model group (DefaultModels if not overriden). See scripts/zombiemodelgroups.txt"
+	
+	shamblercost(float) : "Shambler Cost" : "-1" : "Overrides the resource cost needed to spawn a shambler at this point. Leave at -1 to use the default value, which is normally 10."
+	bansheecost(float) : "Banshee Cost" : "-1" : "Overrides the resource cost needed to spawn a banshee at this point. Leave at -1 to use the default value, which is normally 60."
+	hulkcost(float) : "Hulk Cost" : "-1" : "Overrides the resource cost needed to spawn a hulk at this point. Leave at -1 to use the default value, which is normally 70."
+	driftercost(float) : "Drifter Cost" : "-1" : "Overrides the resource cost needed to spawn a drifter at this point. Leave at -1 to use the default value, which is normally 35."
+	immolatorcost(float) : "Immolator Cost" : "-1" : "Overrides the resource cost needed to spawn an immolator at this point. Leave at -1 to use the default value, which is normally 100."
+	
+	input SetZombieFlags(integer) : "Manually sets the zombies that can be spawned here."
+	input AddZombieFlags(integer) : "Manually adds to the zombies that can be spawned here."
+	input RemoveZombieFlags(integer) : "Manually removes from the zombies that can be spawned here."
+	
+	input EnableShamblerSpawn(void) : "Allows shamblers to spawn here if they were not allowed to before."
+	input EnableBansheeSpawn(void) : "Allows banshees to spawn here if they were not allowed to before."
+	input EnableHulkSpawn(void) : "Allows hulks to spawn here if they were not allowed to before."
+	input EnableDrifterSpawn(void) : "Allows drifters to spawn here if they were not allowed to before."
+	input EnableImmolatorSpawn(void) : "Allows immolators to spawn here if they were not allowed to before."
+	
+	input DisableShamblerSpawn(void) : "Stops shamblers from spawning here if they were allowed to before."
+	input DisableBansheeSpawn(void) : "Stops banshees from spawning here if they were allowed to before."
+	input DisableHulkSpawn(void) : "Stops hulks from spawning here if they were allowed to before."
+	input DisableDrifterSpawn(void) : "Stops drifters from spawning here if they were allowed to before."
+	input DisableImmolatorSpawn(void) : "Stops immolators from spawning here if they were allowed to before."
+	
+	input SetShamblerCost(integer) : "Overrides the cost of this zombie type. -1 reverts to default."
+	input SetBansheeCost(integer) : "Overrides the cost of this zombie type. -1 reverts to default."
+	input SetHulkCost(integer) : "Overrides the cost of this zombie type. -1 reverts to default."
+	input SetDrifterCost(integer) : "Overrides the cost of this zombie type. -1 reverts to default."
+	input SetImmolatorCost(integer) : "Overrides the cost of this zombie type. -1 reverts to default."
+	
+	output OnSpawnNPC(ehandle) : "Fired when a zombie is spawned here. The activator is the zombie, and the parameter is a pointer to the zombie."
+	output OnSpawnShambler(ehandle) : "Fired when a shambler is spawned here. The activator is the shambler, and the parameter is a pointer to the shambler."
+	output OnSpawnBanshee(ehandle) : "Fired when a banshee is spawned here. The activator is the banshee, and the parameter is a pointer to the banshee."
+	output OnSpawnHulk(ehandle) : "Fired when a hulk is spawned here. The activator is the hulk, and the parameter is a pointer to the hulk."
+	output OnSpawnDrifter(ehandle) : "Fired when a drifter is spawned here. The activator is the drifter, and the parameter is a pointer to the drifter."
+	output OnSpawnImmolator(ehandle) : "Fired when a immolator is spawned here. The activator is the immolator, and the parameter is a pointer to the immolator."
 ]
 
 
@@ -107,6 +142,8 @@
 	"Specific spawn point for Zombie Spawn"
 [
 	nodename(target_destination) : "Next Node" : "" : "Next node in the chain, if any."
+	
+	output OnSpawnNPC(ehandle) : "Fired when a zombie is spawned at this node. The activator is the zombie, and the parameter is a pointer to the zombie."
 ]
 
 @PointClass base(Targetname, Parentname, Origin, Angles) = info_rallypoint :
@@ -231,6 +268,7 @@
 @SolidClass base(Targetname, Origin, Activeable, InputActiveable) = trigger_zombiespawnvolume :
 	"A trigger volume that zombies spawn in."
 [
+	output OnSpawnNPC(ehandle) : "Fired when a zombie is spawned in this volume. The activator is the zombie, and the parameter is a pointer to the zombie."
 ]
 
 @SolidClass base(Targetname, Origin, Activeable, InputActiveable) = trigger_blockphysexplosion :

--- a/mp/src/game/client/zmr/c_zmr_entities.cpp
+++ b/mp/src/game/client/zmr/c_zmr_entities.cpp
@@ -99,6 +99,7 @@ int C_ZMEntBaseUsable::DrawModel( int flags )
 */
 IMPLEMENT_CLIENTCLASS_DT( C_ZMEntZombieSpawn, DT_ZM_EntZombieSpawn, CZMEntZombieSpawn )
     RecvPropInt( RECVINFO( m_fZombieFlags ) ),
+    RecvPropArray3( RECVINFO_ARRAY(m_iZombieCosts), RecvPropInt( RECVINFO(m_iZombieCosts[0]) ) ),
 END_RECV_TABLE()
 
 BEGIN_DATADESC( C_ZMEntZombieSpawn )
@@ -108,6 +109,11 @@ END_DATADESC()
 C_ZMEntZombieSpawn::C_ZMEntZombieSpawn()
 {
     m_fZombieFlags = 0;
+
+    for (int i = 0; i < ZMCLASS_MAX; i++)
+    {
+        m_iZombieCosts.Set(i, -1);
+    }
 }
 
 void C_ZMEntZombieSpawn::Precache()

--- a/mp/src/game/client/zmr/c_zmr_entities.h
+++ b/mp/src/game/client/zmr/c_zmr_entities.h
@@ -57,12 +57,14 @@ public:
     void Precache() OVERRIDE;
 
     int GetZombieFlags() { return m_fZombieFlags; };
+    const int* GetZombieCosts() { return m_iZombieCosts.Base(); };
 
 protected:
     virtual void InitSpriteMat() OVERRIDE;
 
 private:
     CNetworkVar( int, m_fZombieFlags );
+    CNetworkArray( int, m_iZombieCosts, ZMCLASS_MAX );
 };
 
 class C_ZMEntManipulate : public C_ZMEntBaseUsable

--- a/mp/src/game/client/zmr/ui/zmr_buildmenu.cpp
+++ b/mp/src/game/client/zmr/ui/zmr_buildmenu.cpp
@@ -281,7 +281,7 @@ void CZMBuildMenu::ShowZombieInfo( int type )
     ZombieClass_t zclass = static_cast<ZombieClass_t>( type );
 
     char buffer[50];
-    Q_snprintf(buffer, sizeof(buffer), "%d", C_ZMBaseZombie::GetCost(zclass) );
+    Q_snprintf(buffer, sizeof(buffer), "%d", GetZombieCosts()[type] );
     info_rescost->SetText(buffer);
 
     Q_snprintf(buffer, sizeof(buffer), "%d", C_ZMBaseZombie::GetPopCost(zclass));
@@ -323,6 +323,7 @@ void CZMBuildMenu::UpdateQueue( const ZMQueueSlotData_t q[], int size )
             queueimages[i]->SetText( buf );
 
             queueimages[i]->UpdateData( q[i].nCount, q[i].zclass );
+            queueimages[i]->SetCost( GetZombieCosts()[type] );
 
 
             zombies_present = true;

--- a/mp/src/game/client/zmr/ui/zmr_buildmenu_base.cpp
+++ b/mp/src/game/client/zmr/ui/zmr_buildmenu_base.cpp
@@ -92,6 +92,16 @@ void CZMBuildMenuBase::ShowMenu( C_ZMEntZombieSpawn* pSpawn )
 {
     SetSpawnIndex( pSpawn->entindex() );
     SetZombieFlags( pSpawn->GetZombieFlags() );
+
+    SetZombieCosts( pSpawn->GetZombieCosts() );
+    for ( int i = 0; i < ZMCLASS_MAX; i++ )
+    {
+        // Zombie costs can be overridden by spawn points.
+        // "-1" means to use the default cost.
+        if ( m_iZombieCosts[i] == -1 )
+            m_iZombieCosts[i] = C_ZMBaseZombie::GetCost( (ZombieClass_t)i );
+    }
+
     ShowPanel( true );
 }
 

--- a/mp/src/game/client/zmr/ui/zmr_buildmenu_base.cpp
+++ b/mp/src/game/client/zmr/ui/zmr_buildmenu_base.cpp
@@ -92,15 +92,7 @@ void CZMBuildMenuBase::ShowMenu( C_ZMEntZombieSpawn* pSpawn )
 {
     SetSpawnIndex( pSpawn->entindex() );
     SetZombieFlags( pSpawn->GetZombieFlags() );
-
     SetZombieCosts( pSpawn->GetZombieCosts() );
-    for ( int i = 0; i < ZMCLASS_MAX; i++ )
-    {
-        // Zombie costs can be overridden by spawn points.
-        // "-1" means to use the default cost.
-        if ( m_iZombieCosts[i] == -1 )
-            m_iZombieCosts[i] = C_ZMBaseZombie::GetCost( (ZombieClass_t)i );
-    }
 
     ShowPanel( true );
 }
@@ -122,6 +114,21 @@ void CZMBuildMenuBase::OnClose()
 	BaseClass::OnClose();
 }
 
+void CZMBuildMenuBase::SetZombieCosts( const int *costs )
+{
+    //memcpy( m_iZombieCosts, costs, sizeof(int) * ZMCLASS_MAX );
+
+	// Zombie costs can be overridden by spawn points.
+    // "-1" means to use the default cost.
+    for ( int i = 0; i < ZMCLASS_MAX; i++ )
+    {
+        if ( costs[i] == -1 )
+            m_iZombieCosts[i] = C_ZMBaseZombie::GetCost( (ZombieClass_t)i );
+        else
+            m_iZombieCosts[i] = costs[i];
+    }
+}
+
 void __MsgFunc_ZMBuildMenuUpdate( bf_read &msg )
 {
     if ( !g_pZMView || !g_pZMView->GetBuildMenu() ) return;
@@ -139,6 +146,16 @@ void __MsgFunc_ZMBuildMenuUpdate( bf_read &msg )
 
 
 	bool active = msg.ReadOneBit() == 1;
+
+
+    pMenu->SetZombieFlags( msg.ReadByte() );
+
+    int iCosts[ZMCLASS_MAX];
+    for ( int i = 0; i < ZMCLASS_MAX; i++ )
+    {
+        iCosts[i] = msg.ReadShort();
+    }
+    pMenu->SetZombieCosts( iCosts );
 
 
     int count = msg.ReadByte();
@@ -165,6 +182,8 @@ void __MsgFunc_ZMBuildMenuUpdate( bf_read &msg )
         pMenu->Close();
 	}
 
+
+    pMenu->UpdateMenuData();
 
 	pMenu->UpdateQueue( pQueue, count );
 

--- a/mp/src/game/client/zmr/ui/zmr_buildmenu_base.h
+++ b/mp/src/game/client/zmr/ui/zmr_buildmenu_base.h
@@ -44,6 +44,7 @@ public:
     virtual int ZMKeyInput( ButtonCode_t keynum, int down );
 
     virtual void ShowMenu( C_ZMEntZombieSpawn* pSpawn );
+    virtual void UpdateMenuData() {};
     virtual void UpdateQueue( const ZMQueueSlotData_t q[], int size ) {};
 
     inline int GetLastSpawnIndex() { return m_iLastSpawnIndex; };
@@ -54,7 +55,7 @@ public:
     inline void SetZombieFlags( int flags ) { m_fSpawnZombieFlags = flags; };
 
     inline int* GetZombieCosts() { return (int*)m_iZombieCosts; };
-    inline void SetZombieCosts( const int *costs ) { memcpy(m_iZombieCosts, costs, sizeof(int) * ZMCLASS_MAX); };
+    void SetZombieCosts( const int *costs );
 
     int GetAltSpawnAmount() const;
 

--- a/mp/src/game/client/zmr/ui/zmr_buildmenu_base.h
+++ b/mp/src/game/client/zmr/ui/zmr_buildmenu_base.h
@@ -53,10 +53,14 @@ public:
     inline int GetZombieFlags() { return m_fSpawnZombieFlags; };
     inline void SetZombieFlags( int flags ) { m_fSpawnZombieFlags = flags; };
 
+    inline int* GetZombieCosts() { return (int*)m_iZombieCosts; };
+    inline void SetZombieCosts( const int *costs ) { memcpy(m_iZombieCosts, costs, sizeof(int) * ZMCLASS_MAX); };
+
     int GetAltSpawnAmount() const;
 
 private:
     int m_iLastSpawnIndex;
     int m_iSpawnIndex;
     int m_fSpawnZombieFlags;
+    int m_iZombieCosts[ZMCLASS_MAX];
 };

--- a/mp/src/game/client/zmr/ui/zmr_buildmenu_new.cpp
+++ b/mp/src/game/client/zmr/ui/zmr_buildmenu_new.cpp
@@ -201,7 +201,7 @@ void CZMBuildMenuNew::OnRadialOver( KeyValues* kv )
                 if ( format )
                 {
                     char buffer[128];
-                    Q_snprintf( buffer, sizeof( buffer ), format, C_ZMBaseZombie::GetPopCost( zclass ), C_ZMBaseZombie::GetCost( zclass ) );
+                    Q_snprintf( buffer, sizeof( buffer ), format, C_ZMBaseZombie::GetPopCost( zclass ), GetZombieCosts()[zclass] );
                     pButton->GetLabel()->SetText( buffer );
                 }
             }

--- a/mp/src/game/client/zmr/ui/zmr_buildmenu_new.cpp
+++ b/mp/src/game/client/zmr/ui/zmr_buildmenu_new.cpp
@@ -170,6 +170,24 @@ void CZMBuildMenuNew::UpdateButtons()
     }
 }
 
+void CZMBuildMenuNew::UpdateButtonData( CZMRadialButton* pButton )
+{
+    // Update pop and cost values.
+    const char* szClass = pButton->GetLabelData() ? pButton->GetLabelData()->GetString( "zombieclass" ) : "";
+
+    if ( *szClass )
+    {
+        ZombieClass_t zclass = C_ZMBaseZombie::NameToClass( szClass );
+        const char* format = g_pVGuiLocalize->FindAsUTF8( "#ZMRadialMouseOver" );
+        if ( format )
+        {
+            char buffer[128];
+            Q_snprintf( buffer, sizeof( buffer ), format, C_ZMBaseZombie::GetPopCost( zclass ), GetZombieCosts()[zclass] );
+            pButton->GetLabel()->SetText( buffer );
+        }
+    }
+}
+
 void CZMBuildMenuNew::OnImageRowPressed( KeyValues* kv )
 {
     // Clear the specific pos on the queue.
@@ -191,20 +209,7 @@ void CZMBuildMenuNew::OnRadialOver( KeyValues* kv )
     {
         if ( pButton->GetLabel() )
         {
-            // Update pop and cost values.
-            const char* szClass = pButton->GetLabelData() ? pButton->GetLabelData()->GetString( "zombieclass" ) : "";
-
-            if ( *szClass )
-            {
-                ZombieClass_t zclass = C_ZMBaseZombie::NameToClass( szClass );
-                const char* format = g_pVGuiLocalize->FindAsUTF8( "#ZMRadialMouseOver" );
-                if ( format )
-                {
-                    char buffer[128];
-                    Q_snprintf( buffer, sizeof( buffer ), format, C_ZMBaseZombie::GetPopCost( zclass ), GetZombieCosts()[zclass] );
-                    pButton->GetLabel()->SetText( buffer );
-                }
-            }
+            UpdateButtonData( pButton );
 
             pButton->GetLabel()->SetVisible( true );
         }
@@ -253,6 +258,14 @@ void CZMBuildMenuNew::ShowMenu( C_ZMEntZombieSpawn* pSpawn )
 
 
     BaseClass::ShowMenu( pSpawn );
+}
+
+void CZMBuildMenuNew::UpdateMenuData()
+{
+    if ( m_pRadial && m_pRadial->GetLastButton() && m_pRadial->GetLastButton()->GetLabel() )
+    {
+        UpdateButtonData( m_pRadial->GetLastButton() );
+    }
 }
 
 void CZMBuildMenuNew::UpdateQueue( const ZMQueueSlotData_t queue[], int size )

--- a/mp/src/game/client/zmr/ui/zmr_buildmenu_new.h
+++ b/mp/src/game/client/zmr/ui/zmr_buildmenu_new.h
@@ -41,10 +41,13 @@ public:
     virtual const char* GetName() OVERRIDE { return "ZMBuildMenuNew"; };
 
     virtual void ShowMenu( C_ZMEntZombieSpawn* pSpawn ) OVERRIDE;
+    virtual void UpdateMenuData() OVERRIDE;
     virtual void UpdateQueue( const ZMQueueSlotData_t queue[], int size ) OVERRIDE;
 
 private:
     void UpdateButtons();
+
+    void UpdateButtonData( CZMRadialButton* pButton );
 
     CZMRadialPanel* m_pRadial;
     CZMImageRow* m_pImageList;

--- a/mp/src/game/client/zmr/ui/zmr_buildmenu_spawnicon.cpp
+++ b/mp/src/game/client/zmr/ui/zmr_buildmenu_spawnicon.cpp
@@ -29,6 +29,7 @@ void CZMImageRowItemSpawn::ResetMe()
 {
     m_flStartTime = 0.0f;
     m_nCount = 0;
+    m_iCost = -1;
     m_iZombieClass = ZMCLASS_INVALID;
     m_bIsPrimary = false;
     m_flDelay = 0.1f;
@@ -143,7 +144,7 @@ bool CZMImageRowItemSpawn::CanSpawn() const
     if ( !pPlayer || !pPlayer->IsZM() )
         return false;
 
-    if ( !pPlayer->HasEnoughResToSpawn( m_iZombieClass ) )
+    if ( !pPlayer->HasEnoughRes( m_iCost ) )
         return false;
     
     if ( !C_ZMBaseZombie::HasEnoughPopToSpawn( m_iZombieClass ) )

--- a/mp/src/game/client/zmr/ui/zmr_buildmenu_spawnicon.h
+++ b/mp/src/game/client/zmr/ui/zmr_buildmenu_spawnicon.h
@@ -28,11 +28,14 @@ public:
     bool CanSpawn() const;
     void SetPrimary() { m_bIsPrimary = true; }
 
+    void SetCost( int pCost ) { m_iCost = pCost; }
+
     void ResetMe();
 
 private:
     float m_flStartTime;
     int m_nCount;
+    int m_iCost;
     ZombieClass_t m_iZombieClass;
     bool m_bIsPrimary;
     float m_flDelay;

--- a/mp/src/game/client/zmr/ui/zmr_radial.h
+++ b/mp/src/game/client/zmr/ui/zmr_radial.h
@@ -79,6 +79,7 @@ public:
     void                            AddButton( KeyValues* kv );
     void                            LoadFromFile( const char* file );
     CUtlVector<CZMRadialButton*>*   GetButtons() { return &m_Buttons; };
+    CZMRadialButton*				GetLastButton() { return m_pLastButton; }
 
     void SetBackgroundImage( const char* image );
 

--- a/mp/src/game/client/zmr/ui/zmr_zmview_base.cpp
+++ b/mp/src/game/client/zmr/ui/zmr_zmview_base.cpp
@@ -677,6 +677,7 @@ void CZMViewBase::OnRightRelease()
     {
         bool bPlayer = false;
         bool bObj = false;
+        bool bIsOnZombieTeam = pTarget->GetTeamNumber() == ZMTEAM_ZM; // Don't attack objects associated with the ZM.
 
         if ( pTarget->IsPlayer() )
         {
@@ -689,7 +690,7 @@ void CZMViewBase::OnRightRelease()
             bObj = (phys && phys->IsMoveable()) || !pTarget->IsBaseTrain();
         }
 
-        if ( bObj )
+        if ( bObj && !bIsOnZombieTeam )
         {
             bool bForceBreak = IsDoubleClickRight();
 

--- a/mp/src/game/server/entitylist.cpp
+++ b/mp/src/game/server/entitylist.cpp
@@ -22,6 +22,10 @@
 #include "npc_playercompanion.h"
 #endif // HL2_DLL
 
+#ifdef ZMR
+#include "zmr_shareddefs.h"
+#endif
+
 // memdbgon must be the last include file in a .cpp file!!!
 #include "tier0/memdbgon.h"
 
@@ -541,6 +545,20 @@ CBaseEntity *CGlobalEntityList::FindEntityProcedural( const char *szName, CBaseE
 			}
 
 		}
+#ifdef ZMR
+		else if ( FStrEq( pName, "zm" ) )
+		{
+			// Return the first player found on the ZM team
+			for (int i = 1; i <= gpGlobals->maxClients; i++)
+			{
+				CBasePlayer *pPlayer = UTIL_PlayerByIndex( i );
+				if (pPlayer && pPlayer->GetTeamNumber() == ZMTEAM_ZM)
+				{
+					return pPlayer;
+				}
+			}
+		}
+#endif
 		else if ( FStrEq( pName, "activator" ) )
 		{
 			return pActivator;

--- a/mp/src/game/server/zmr/zmr_entities.cpp
+++ b/mp/src/game/server/zmr/zmr_entities.cpp
@@ -300,16 +300,22 @@ void CZMEntZombieSpawn::Spawn()
     }
 }
 
+bool CZMEntZombieSpawn::AcceptInput( const char *szInputName, CBaseEntity *pActivator, CBaseEntity *pCaller, variant_t Value, int outputID )
+{
+    bool base = BaseClass::AcceptInput( szInputName, pActivator, pCaller, Value, outputID );
+
+    // Update the menu in response to any valid input
+    if ( base ) SendMenuUpdate();
+
+    return base;
+}
+
 void CZMEntZombieSpawn::InputToggle( inputdata_t &inputdata )
 {
     BaseClass::InputToggle( inputdata );
 
     if ( IsActive() ) StartSpawning();
-    else
-    {
-        StopSpawning();
-        SendMenuUpdate(); // Make sure we close the menu.
-    }
+    else StopSpawning();
 }
 
 void CZMEntZombieSpawn::InputHide( inputdata_t &inputdata )
@@ -317,7 +323,6 @@ void CZMEntZombieSpawn::InputHide( inputdata_t &inputdata )
     BaseClass::InputHide( inputdata );
 
     StopSpawning();
-    SendMenuUpdate(); // Make sure we close the menu.
 }
 
 void CZMEntZombieSpawn::InputUnhide( inputdata_t &inputdata )
@@ -325,21 +330,6 @@ void CZMEntZombieSpawn::InputUnhide( inputdata_t &inputdata )
     BaseClass::InputUnhide( inputdata );
 
     StartSpawning();
-}
-
-void CZMEntZombieSpawn::InputSetZombieFlags( inputdata_t &inputdata )
-{
-    m_fZombieFlags = inputdata.value.Int();
-}
-
-void CZMEntZombieSpawn::InputAddZombieFlags( inputdata_t &inputdata )
-{
-    m_fZombieFlags |= inputdata.value.Int();
-}
-
-void CZMEntZombieSpawn::InputRemoveZombieFlags( inputdata_t &inputdata )
-{
-    m_fZombieFlags &= ~inputdata.value.Int();
 }
 
 bool CZMEntZombieSpawn::CanSpawn( ZombieClass_t zclass )
@@ -472,6 +462,12 @@ void CZMEntZombieSpawn::SendMenuUpdate()
 		WRITE_SHORT( entindex() );
 
 		WRITE_BOOL( IsActive() );
+
+        WRITE_BYTE( m_fZombieFlags );
+        for ( int i = 0; i < ZMCLASS_MAX; i++ )
+        {
+            WRITE_SHORT( m_iZombieCosts[i] );
+        }
 
         int count = m_vSpawnQueue.Count();
         WRITE_BYTE( count );

--- a/mp/src/game/server/zmr/zmr_entities.cpp
+++ b/mp/src/game/server/zmr/zmr_entities.cpp
@@ -187,6 +187,7 @@ int CZMEntBaseSimple::UpdateTransmitState()
 */
 IMPLEMENT_SERVERCLASS_ST( CZMEntZombieSpawn, DT_ZM_EntZombieSpawn )
     SendPropInt( SENDINFO( m_fZombieFlags ) ),
+    SendPropArray3( SENDINFO_ARRAY3(m_iZombieCosts), SendPropInt( SENDINFO_ARRAY(m_iZombieCosts), 16 ) ), // Resource cost is not likely to surpass 16 bits
 END_SEND_TABLE()
 
 BEGIN_DATADESC( CZMEntZombieSpawn )
@@ -196,6 +197,28 @@ BEGIN_DATADESC( CZMEntZombieSpawn )
     DEFINE_INPUTFUNC( FIELD_VOID, "Hide", InputHide ),
     DEFINE_INPUTFUNC( FIELD_VOID, "Unhide", InputUnhide ),
 
+    DEFINE_INPUTFUNC( FIELD_INTEGER, "SetZombieFlags", InputSetZombieFlags ),
+    DEFINE_INPUTFUNC( FIELD_INTEGER, "AddZombieFlags", InputAddZombieFlags ),
+    DEFINE_INPUTFUNC( FIELD_INTEGER, "RemoveZombieFlags", InputRemoveZombieFlags ),
+
+    DEFINE_INPUTFUNC( FIELD_VOID, "EnableShamblerSpawn", InputEnableZombie0 ),
+    DEFINE_INPUTFUNC( FIELD_VOID, "EnableBansheeSpawn", InputEnableZombie1 ),
+    DEFINE_INPUTFUNC( FIELD_VOID, "EnableHulkSpawn", InputEnableZombie2 ),
+    DEFINE_INPUTFUNC( FIELD_VOID, "EnableDrifterSpawn", InputEnableZombie3 ),
+    DEFINE_INPUTFUNC( FIELD_VOID, "EnableImmolatorSpawn", InputEnableZombie4 ),
+
+    DEFINE_INPUTFUNC( FIELD_VOID, "DisableShamblerSpawn", InputDisableZombie0 ),
+    DEFINE_INPUTFUNC( FIELD_VOID, "DisableBansheeSpawn", InputDisableZombie1 ),
+    DEFINE_INPUTFUNC( FIELD_VOID, "DisableHulkSpawn", InputDisableZombie2 ),
+    DEFINE_INPUTFUNC( FIELD_VOID, "DisableDrifterSpawn", InputDisableZombie3 ),
+    DEFINE_INPUTFUNC( FIELD_VOID, "DisableImmolatorSpawn", InputDisableZombie4 ),
+
+    DEFINE_INPUTFUNC( FIELD_INTEGER, "SetShamblerCost", InputSetZombieCost0 ),
+    DEFINE_INPUTFUNC( FIELD_INTEGER, "SetBansheeCost", InputSetZombieCost1 ),
+    DEFINE_INPUTFUNC( FIELD_INTEGER, "SetHulkCost", InputSetZombieCost2 ),
+    DEFINE_INPUTFUNC( FIELD_INTEGER, "SetDrifterCost", InputSetZombieCost3 ),
+    DEFINE_INPUTFUNC( FIELD_INTEGER, "SetImmolatorCost", InputSetZombieCost4 ),
+
 
     DEFINE_KEYFIELD( m_fZombieFlags, FIELD_INTEGER, "zombieflags" ),
     //DEFINE_KEYFIELD( m_nSpawnQueueCapacity, FIELD_INTEGER, "spawnqueuecapacity" ),
@@ -203,6 +226,20 @@ BEGIN_DATADESC( CZMEntZombieSpawn )
     DEFINE_KEYFIELD( m_sFirstNodeName, FIELD_STRING, "nodename" ),
 
     DEFINE_KEYFIELD( m_sZombieModelGroup, FIELD_STRING, "modelgroup" ),
+
+    DEFINE_KEYFIELD( m_iZombieCosts[0], FIELD_INTEGER, "shamblercost" ),
+    DEFINE_KEYFIELD( m_iZombieCosts[1], FIELD_INTEGER, "bansheecost" ),
+    DEFINE_KEYFIELD( m_iZombieCosts[2], FIELD_INTEGER, "hulkcost" ),
+    DEFINE_KEYFIELD( m_iZombieCosts[3], FIELD_INTEGER, "driftercost" ),
+    DEFINE_KEYFIELD( m_iZombieCosts[4], FIELD_INTEGER, "immolatorcost" ),
+
+    DEFINE_OUTPUT( m_OnSpawnZMClass[0], "OnSpawnShambler" ),
+    DEFINE_OUTPUT( m_OnSpawnZMClass[1], "OnSpawnBanshee" ),
+    DEFINE_OUTPUT( m_OnSpawnZMClass[2], "OnSpawnHulk" ),
+    DEFINE_OUTPUT( m_OnSpawnZMClass[3], "OnSpawnDrifter" ),
+    DEFINE_OUTPUT( m_OnSpawnZMClass[4], "OnSpawnImmolator" ),
+
+    DEFINE_OUTPUT( m_OnSpawnNPC, "OnSpawnNPC" ),
 
     DEFINE_THINKFUNC( SpawnThink ),
 END_DATADESC()
@@ -215,6 +252,11 @@ CZMEntZombieSpawn::CZMEntZombieSpawn()
 {
     m_vSpawnNodes.Purge();
     m_vSpawnQueue.Purge();
+
+    for (int i = 0; i < ZMCLASS_MAX; i++)
+    {
+        m_iZombieCosts.Set(i, -1);
+    }
 }
 
 void CZMEntZombieSpawn::Precache()
@@ -283,6 +325,21 @@ void CZMEntZombieSpawn::InputUnhide( inputdata_t &inputdata )
     BaseClass::InputUnhide( inputdata );
 
     StartSpawning();
+}
+
+void CZMEntZombieSpawn::InputSetZombieFlags( inputdata_t &inputdata )
+{
+    m_fZombieFlags = inputdata.value.Int();
+}
+
+void CZMEntZombieSpawn::InputAddZombieFlags( inputdata_t &inputdata )
+{
+    m_fZombieFlags |= inputdata.value.Int();
+}
+
+void CZMEntZombieSpawn::InputRemoveZombieFlags( inputdata_t &inputdata )
+{
+    m_fZombieFlags &= ~inputdata.value.Int();
 }
 
 bool CZMEntZombieSpawn::CanSpawn( ZombieClass_t zclass )
@@ -461,7 +518,7 @@ void CZMEntZombieSpawn::SpawnThink()
     ZombieClass_t zclass = queue.m_zclass;
 
 
-    int cost = CZMBaseZombie::GetCost( zclass );
+    int cost = m_iZombieCosts[zclass] == -1 ? CZMBaseZombie::GetCost( zclass ) : m_iZombieCosts[zclass];
     bool bCreate = true;
     CZMPlayer* pPlayer = nullptr;
 
@@ -540,7 +597,8 @@ CZMBaseZombie* CZMEntZombieSpawn::CreateZombie( ZombieClass_t zclass )
     Vector spawnpos;
     QAngle ang = vec3_angle;
 
-    if ( !FindSpawnPoint( pZombie, spawnpos, ang ) )
+    CBaseEntity* pSpawnPoint = FindSpawnPoint( pZombie, spawnpos, ang );
+    if ( !pSpawnPoint )
     {
         UTIL_RemoveImmediate( pZombie );
         return nullptr;
@@ -567,6 +625,20 @@ CZMBaseZombie* CZMEntZombieSpawn::CreateZombie( ZombieClass_t zclass )
     pZombie->Activate();
 
 
+    // Fire outputs in case the mapper wants to do something with the zombies spawned here
+    m_OnSpawnNPC.Set( pZombie, pZombie, this );
+	m_OnSpawnZMClass[pZombie->GetZombieClass()].Set( pZombie, pZombie, this );
+
+    if ( pSpawnPoint != this )
+    {
+        // Also fire an output on what could be either a spawn node or a spawn volume.
+        // We could do classname check + dynamic_casting instead, but doing it this way is more flexible.
+        variant_t variant;
+        variant.SetEntity( pZombie );
+        pSpawnPoint->FireNamedOutput( "OnSpawnNPC", variant, pZombie, pSpawnPoint );
+    }
+
+
     if ( m_pRallyPoint )
     {
         DevMsg( "Commanding zombie to rallypoint...\n" );
@@ -584,9 +656,9 @@ CZMBaseZombie* CZMEntZombieSpawn::CreateZombie( ZombieClass_t zclass )
     return pZombie;
 }
 
-bool CZMEntZombieSpawn::FindSpawnPoint( CZMBaseZombie* pZombie, Vector& outpos, QAngle& outang )
+CBaseEntity* CZMEntZombieSpawn::FindSpawnPoint( CZMBaseZombie* pZombie, Vector& outpos, QAngle& outang )
 {
-    if ( !pZombie ) return false;
+    if ( !pZombie ) return nullptr;
 
 
     // We have no spawn nodes, so find em.
@@ -648,7 +720,7 @@ bool CZMEntZombieSpawn::FindSpawnPoint( CZMBaseZombie* pZombie, Vector& outpos, 
             if ( pBrush )
             {
                 pBrush->GetPositionWithin( outpos );
-                return true;
+                return pBrush;
             }
         }
     }
@@ -665,7 +737,7 @@ bool CZMEntZombieSpawn::FindSpawnPoint( CZMBaseZombie* pZombie, Vector& outpos, 
         {
             outpos = pNode->GetAbsOrigin();
             outang = pNode->GetAbsAngles();
-            return true;
+            return pNode;
         }
 
         // Try any node.
@@ -677,7 +749,7 @@ bool CZMEntZombieSpawn::FindSpawnPoint( CZMBaseZombie* pZombie, Vector& outpos, 
             {
                 outpos = pNode->GetAbsOrigin();
                 outang = pNode->GetAbsAngles();
-                return true;
+                return pNode;
             }
         }
     }
@@ -700,11 +772,11 @@ bool CZMEntZombieSpawn::FindSpawnPoint( CZMBaseZombie* pZombie, Vector& outpos, 
             Vector dir = pos - GetAbsOrigin(); // Face away from the zombie spawn.
             outang.y = RAD2DEG( atan2f( dir.y, dir.x ) );
 
-            return true;
+            return this;
         }
     }
 
-    return false;
+    return nullptr;
 }
 
 
@@ -713,6 +785,7 @@ bool CZMEntZombieSpawn::FindSpawnPoint( CZMBaseZombie* pZombie, Vector& outpos, 
 */
 BEGIN_DATADESC( CZMEntSpawnNode )
     DEFINE_KEYFIELD( m_sNextNodeName, FIELD_STRING, "nodename" ),
+    DEFINE_OUTPUT( m_OnSpawnNPC, "OnSpawnNPC" ),
 END_DATADESC()
 
 LINK_ENTITY_TO_CLASS( info_spawnnode, CZMEntSpawnNode );
@@ -2287,6 +2360,8 @@ BEGIN_DATADESC( CZMEntTriggerSpawnVolume )
     DEFINE_INPUTFUNC( FIELD_VOID, "Toggle", InputToggle ),
     DEFINE_INPUTFUNC( FIELD_VOID, "Disable", InputDisable ),
     DEFINE_INPUTFUNC( FIELD_VOID, "Enable", InputEnable ),
+
+    DEFINE_OUTPUT( m_OnSpawnNPC, "OnSpawnNPC" ),
 END_DATADESC()
 
 LINK_ENTITY_TO_CLASS( trigger_zombiespawnvolume, CZMEntTriggerSpawnVolume );

--- a/mp/src/game/server/zmr/zmr_entities.h
+++ b/mp/src/game/server/zmr/zmr_entities.h
@@ -109,6 +109,24 @@ public:
     void InputToggle( inputdata_t &inputdata );
     void InputHide( inputdata_t &inputdata );
     void InputUnhide( inputdata_t &inputdata );
+    void InputSetZombieFlags( inputdata_t &inputdata );
+    void InputAddZombieFlags( inputdata_t &inputdata );
+    void InputRemoveZombieFlags( inputdata_t &inputdata );
+    void InputEnableZombie0( inputdata_t& inputdata ) { m_fZombieFlags |= 1 << 0; }
+    void InputEnableZombie1( inputdata_t& inputdata ) { m_fZombieFlags |= 1 << 1; }
+    void InputEnableZombie2( inputdata_t& inputdata ) { m_fZombieFlags |= 1 << 2; }
+    void InputEnableZombie3( inputdata_t& inputdata ) { m_fZombieFlags |= 1 << 3; }
+    void InputEnableZombie4( inputdata_t& inputdata ) { m_fZombieFlags |= 1 << 4; }
+    void InputDisableZombie0( inputdata_t& inputdata ) { m_fZombieFlags &= ~(1 << 0); }
+    void InputDisableZombie1( inputdata_t& inputdata ) { m_fZombieFlags &= ~(1 << 1); }
+    void InputDisableZombie2( inputdata_t& inputdata ) { m_fZombieFlags &= ~(1 << 2); }
+    void InputDisableZombie3( inputdata_t& inputdata ) { m_fZombieFlags &= ~(1 << 3); }
+    void InputDisableZombie4( inputdata_t& inputdata ) { m_fZombieFlags &= ~(1 << 4); }
+    void InputSetZombieCost0( inputdata_t &inputdata ) { m_iZombieCosts.Set( 0, inputdata.value.Int() ); }
+    void InputSetZombieCost1( inputdata_t &inputdata ) { m_iZombieCosts.Set( 1, inputdata.value.Int() ); }
+    void InputSetZombieCost2( inputdata_t &inputdata ) { m_iZombieCosts.Set( 2, inputdata.value.Int() ); }
+    void InputSetZombieCost3( inputdata_t &inputdata ) { m_iZombieCosts.Set( 3, inputdata.value.Int() ); }
+    void InputSetZombieCost4( inputdata_t &inputdata ) { m_iZombieCosts.Set( 4, inputdata.value.Int() ); }
 
 
     void SpawnThink();
@@ -132,7 +150,7 @@ private:
     void StartSpawning();
     void StopSpawning();
 
-    bool FindSpawnPoint( CZMBaseZombie* pZombie, Vector& output, QAngle& outang );
+    CBaseEntity* FindSpawnPoint( CZMBaseZombie* pZombie, Vector& output, QAngle& outang );
 
     void SetNextSpawnThink();
     float GetSpawnDelay() const;
@@ -147,6 +165,11 @@ private:
     string_t m_sZombieModelGroup;
     string_t m_sRallyName;
     string_t m_sFirstNodeName;
+
+    CNetworkArray( int, m_iZombieCosts, ZMCLASS_MAX );
+    COutputEHANDLE m_OnSpawnZMClass[ZMCLASS_MAX];
+
+    COutputEHANDLE m_OnSpawnNPC;
 
     //int m_fZombieFlags;
     CNetworkVar( int, m_fZombieFlags );
@@ -166,6 +189,9 @@ public:
     void Precache() OVERRIDE;
 
     string_t m_sNextNodeName;
+
+    // This is fired (with its parameter) from info_zombiespawn right now
+    COutputEvent m_OnSpawnNPC;
 };
 
 
@@ -530,4 +556,7 @@ public:
 
 private:
     bool m_bActive;
+
+    // This is fired (with its parameter) from info_zombiespawn right now
+    COutputEvent m_OnSpawnNPC;
 };

--- a/mp/src/game/server/zmr/zmr_entities.h
+++ b/mp/src/game/server/zmr/zmr_entities.h
@@ -106,12 +106,14 @@ public:
     void Spawn() OVERRIDE;
     void Precache() OVERRIDE;
 
+    bool AcceptInput( const char *szInputName, CBaseEntity *pActivator, CBaseEntity *pCaller, variant_t Value, int outputID ) OVERRIDE;
+
     void InputToggle( inputdata_t &inputdata );
     void InputHide( inputdata_t &inputdata );
     void InputUnhide( inputdata_t &inputdata );
-    void InputSetZombieFlags( inputdata_t &inputdata );
-    void InputAddZombieFlags( inputdata_t &inputdata );
-    void InputRemoveZombieFlags( inputdata_t &inputdata );
+    void InputSetZombieFlags( inputdata_t &inputdata ) { m_fZombieFlags = inputdata.value.Int(); }
+    void InputAddZombieFlags( inputdata_t &inputdata ) { m_fZombieFlags |= inputdata.value.Int(); }
+    void InputRemoveZombieFlags( inputdata_t &inputdata ) { m_fZombieFlags &= ~inputdata.value.Int(); }
     void InputEnableZombie0( inputdata_t& inputdata ) { m_fZombieFlags |= 1 << 0; }
     void InputEnableZombie1( inputdata_t& inputdata ) { m_fZombieFlags |= 1 << 1; }
     void InputEnableZombie2( inputdata_t& inputdata ) { m_fZombieFlags |= 1 << 2; }

--- a/mp/src/game/server/zmr/zmr_zm_commands.cpp
+++ b/mp/src/game/server/zmr/zmr_zm_commands.cpp
@@ -69,6 +69,7 @@ void ZM_Cmd_Target( const CCommand &args )
     bool bSwat = false; // Just swat the object away/towards an enemy.
     bool bIsBreakable = false;
     bool bCanBeDamaged = pTarget->GetHealth() > 0 && pTarget->m_takedamage == DAMAGE_YES;
+    bool bIsOnZombieTeam = pTarget->GetTeamNumber() == ZMTEAM_ZM; // Don't attack objects associated with the ZM.
     
     if ( pTarget->IsPlayer() )
     {
@@ -93,7 +94,7 @@ void ZM_Cmd_Target( const CCommand &args )
 
 
     // Can't really do anything here, just move.
-    if ( !bTarget && !bCanBeDamaged && !bSwat )
+    if ( (!bTarget && !bCanBeDamaged && !bSwat) || bIsOnZombieTeam )
     {
         ZMUtil::MoveSelectedZombies( pPlayer->entindex(), pos );
         return;


### PR DESCRIPTION
A small collection of additions for what's available to mappers.

- Implemented a bunch of new I/O and keyvalues on `info_zombiespawn` partly based on the suggestions in DoofusCockslap's issue (https://github.com/zm-reborn/zmr-game/issues/233).
- Added `!zm` procedural name (https://github.com/zm-reborn/zmr-game/issues/142).
- Made it so zombies won't attack non-player entities assigned to the ZM team (currently just manually set by the mapper through an unmarked input or keyvalue). Clicks from the ZM will be treated as move orders.

I made sure to follow the contribution guidelines on the repo wiki and mimicked the style of the surrounding code.

---

`info_zombiespawn` has 5 new keyvalues and 5 new inputs for separately controlling the resource cost of all 5 types of zombies.

<p align="center">
<img src="https://cdn.discordapp.com/attachments/637736357791268867/643143455664766977/unknown.png" width="768"/>
<img src="https://cdn.discordapp.com/attachments/637736357791268867/643143542725672960/zmr_airshipattack0006.jpg" width="768"/>
</p>

`info_zombiespawn` also has 6 new outputs for detecting when a zombie is spawned. 5 of the outputs, `OnSpawnShambler/Banshee/Hulk/Drifter/Immolator`, fire for specific zombie classes. One of the outputs, `OnSpawnNPC`, fires for every zombie. Each output fires with the spawned zombie as the activator.

`info_spawnnode` and `trigger_zombiespawnvolume` also have the all-purpose `OnSpawnNPC` output for when a zombie spawns on/in them, but no zombie-specific outputs.

In combination with these spawn outputs, some logic entities, and the new cost inputs, this allows for mappers to make zombie costs dynamically increase as suggested by the unnamed Discord user mentioned in https://github.com/zm-reborn/zmr-game/issues/233.

The ability to toggle zombie permissions in the middle of a game has also been added to `info_zombiespawn` via 13 new inputs. 10 of those inputs separately enable and disable the permissions of the 5 zombie classes. The other 3 manually control the bit-based zombie flags all at once.

Live changes to the costs or zombie spawn permissions will correctly update if the ZM already has the spawn menu open. This applies to both the classic ZM menu and the new radial menu.

Population costs have not been changed.

---

The `!zm` procedural name allows mappers to access the ZM player entity manually like you would access an output's activator with `!activator` or the player in singleplayer games with `!player`. It should work identically to other procedural names.

If there are multiple ZMs, `!zm` will only return the first player on the ZM team.

---

I added that last bit with the objects on the ZM team for an experimental map I'm making where zombies walk on a func_breakable they shouldn't attack, but I think it could easily see some utility in other maps. They currently still try to attack when the entity blocks their navigation, but I can fix that later.