### PR TITLE
New info_manipulate inputs, ZM team assignment in the FGD, etc.

### DIFF
--- a/mp/game/zombie_master_reborn/fgd/zmr_base_classes.fgd
+++ b/mp/game/zombie_master_reborn/fgd/zmr_base_classes.fgd
@@ -28,3 +28,16 @@
 	
 	input SetGlowColor(color255) : "Change glow color. Format: <Red 0-255> <Green 0-255> <Blue 0-255>"
 ]
+
+@BaseClass = ZMTeam
+[
+	TeamNum(choices) : "Team Assignment" : 0 : "Assigns this entity to a specific team, which can cause the game to treat it differently. For example, a func_breakable on the ZM team cannot be attacked by zombies." =
+	[
+		0 : "None"
+		1 : "Spectator"
+		2 : "Human"
+		3 : "Zombie Master"
+	]
+	
+	input SetTeam(integer) : "Sets this entity's team."
+]

--- a/mp/game/zombie_master_reborn/fgd/zmr_base_game.fgd
+++ b/mp/game/zombie_master_reborn/fgd/zmr_base_game.fgd
@@ -265,7 +265,7 @@
 	ResponseContext(string) : "Response Contexts" : "" : "Response system context(s) for this entity. Format should be: 'key:value,key2:value2,etc'. When this entity speaks, the list of keys & values will be passed to the response rules system."
 ]
 
-@BaseClass base(Targetname, DamageFilter, Shadow) = Breakable
+@BaseClass base(Targetname, DamageFilter, Shadow, ZMTeam) = Breakable
 [
 	ExplodeDamage(float) : "Explosion Damage" : 0 : "If non-zero, when this entity breaks it will create an explosion that causes the specified amount of damage. See also 'Explosion Radius'."
 	ExplodeRadius(float) : "Explosion Radius" : 0 : "If non-zero, when this entity breaks it will create an explosion with a radius of the specified amount. See also 'Explosion Damage'."

--- a/mp/game/zombie_master_reborn/zombie_master_reborn.fgd
+++ b/mp/game/zombie_master_reborn/zombie_master_reborn.fgd
@@ -74,11 +74,14 @@
 	"Manipulatable object by the Zombie Master"
 [
 	Cost(integer) : "Cost" : 10 : "The amount of resources deducted upon activation"
-	output OnPressed(void) : "Fired when the button is pressed."
-
 	Description(string) : "Description" : "" : "Description of this Manipulate's functions."
 	TrapCost(integer) : "TrapCost" : 0 : "Override the trap cost."
 
+	input SetDescription(string) : "Sets the description."
+	input SetTrapCost(integer) : "Sets the trap cost override."
+	input SetCost(integer) : "Sets the cost."
+	
+	output OnPressed(void) : "Fired when the button is pressed."
 ]
 
 @PointClass base(Targetname, Parentname, Origin, Angles, Activeable, InputActiveable)  = info_zombiespawn :

--- a/mp/src/game/client/zmr/c_zmr_entities.cpp
+++ b/mp/src/game/client/zmr/c_zmr_entities.cpp
@@ -3,6 +3,8 @@
 #include "c_zmr_precipitation.h"
 #include "c_zmr_entities.h"
 #include "zmr/zmr_player_shared.h"
+#include "zmr/ui/zmr_buildmenu_base.h"
+#include "zmr/ui/zmr_manimenu_base.h"
 
 // memdbgon must be the last include file in a .cpp file!!!
 #include "tier0/memdbgon.h"
@@ -123,6 +125,16 @@ void C_ZMEntZombieSpawn::Precache()
     PrecacheModel( MAT_SPAWNSPRITE );
 }
 
+void C_ZMEntZombieSpawn::OnDataChanged( DataUpdateType_t type )
+{
+	if ( GetMenu() )
+	{
+		GetMenu()->UpdateMenu( this );
+	}
+
+    BaseClass::OnDataChanged( type );
+}
+
 void C_ZMEntZombieSpawn::InitSpriteMat()
 {
     if ( m_SpriteMat == nullptr )
@@ -157,6 +169,16 @@ void C_ZMEntManipulate::Precache()
     BaseClass::Precache();
 
     PrecacheModel( MAT_MANISPRITE );
+}
+
+void C_ZMEntManipulate::OnDataChanged( DataUpdateType_t type )
+{
+	if ( GetMenu() )
+	{
+		GetMenu()->UpdateMenu( this );
+	}
+
+    BaseClass::OnDataChanged( type );
 }
 
 void C_ZMEntManipulate::InitSpriteMat()

--- a/mp/src/game/client/zmr/c_zmr_entities.h
+++ b/mp/src/game/client/zmr/c_zmr_entities.h
@@ -5,6 +5,9 @@
 
 #include "zmr/zmr_shareddefs.h"
 
+class CZMBuildMenuBase;
+class CZMManiMenuBase;
+
 
 abstract_class C_ZMEntBaseSimple : public C_BaseAnimating
 {
@@ -56,8 +59,13 @@ public:
 
     void Precache() OVERRIDE;
 
+	void OnDataChanged( DataUpdateType_t type ) OVERRIDE;
+
     int GetZombieFlags() { return m_fZombieFlags; };
     const int* GetZombieCosts() { return m_iZombieCosts.Base(); };
+
+	void SetMenu( CZMBuildMenuBase* pMenu ) { m_pBuildMenu = pMenu; };
+	CZMBuildMenuBase* GetMenu() { return m_pBuildMenu; };
 
 protected:
     virtual void InitSpriteMat() OVERRIDE;
@@ -65,6 +73,8 @@ protected:
 private:
     CNetworkVar( int, m_fZombieFlags );
     CNetworkArray( int, m_iZombieCosts, ZMCLASS_MAX );
+
+	CZMBuildMenuBase* m_pBuildMenu;
 };
 
 class C_ZMEntManipulate : public C_ZMEntBaseUsable
@@ -84,6 +94,11 @@ public:
 
     inline const char* GetDescription() { return m_sDescription; };
 
+	void OnDataChanged( DataUpdateType_t type ) OVERRIDE;
+
+	void SetMenu( CZMManiMenuBase* pMenu ) { m_pManiMenu = pMenu; };
+	CZMManiMenuBase* GetMenu() { return m_pManiMenu; };
+
 protected:
     virtual void InitSpriteMat() OVERRIDE;
 
@@ -92,6 +107,8 @@ protected:
 private:
     CNetworkVar( int, m_nCost );
     CNetworkVar( int, m_nTrapCost );
+
+	CZMManiMenuBase* m_pManiMenu;
 };
 
 class C_ZMEntPrecipitation : public C_BaseEntity

--- a/mp/src/game/client/zmr/ui/zmr_buildmenu.cpp
+++ b/mp/src/game/client/zmr/ui/zmr_buildmenu.cpp
@@ -178,7 +178,7 @@ void CZMBuildMenu::ShowPanel( bool state )
     if ( state )
     {
         // Notify the server we've opened this menu.
-        engine->ClientCmd( VarArgs( "zm_cmd_openbuildmenu %i", GetSpawnIndex() ) );
+        engine->ClientCmd( VarArgs( "zm_cmd_openmenu %i", GetSpawnIndex() ) );
     }
 
 

--- a/mp/src/game/client/zmr/ui/zmr_buildmenu_base.cpp
+++ b/mp/src/game/client/zmr/ui/zmr_buildmenu_base.cpp
@@ -93,8 +93,15 @@ void CZMBuildMenuBase::ShowMenu( C_ZMEntZombieSpawn* pSpawn )
     SetSpawnIndex( pSpawn->entindex() );
     SetZombieFlags( pSpawn->GetZombieFlags() );
     SetZombieCosts( pSpawn->GetZombieCosts() );
+	pSpawn->SetMenu( this );
 
     ShowPanel( true );
+}
+
+void CZMBuildMenuBase::UpdateMenu( C_ZMEntZombieSpawn* pSpawn )
+{
+    SetZombieFlags( pSpawn->GetZombieFlags() );
+    SetZombieCosts( pSpawn->GetZombieCosts() );
 }
 
 int CZMBuildMenuBase::GetAltSpawnAmount() const
@@ -106,7 +113,7 @@ int CZMBuildMenuBase::GetAltSpawnAmount() const
 void CZMBuildMenuBase::OnClose()
 {
     // Notify server we've closed this menu.
-    engine->ClientCmd( VarArgs( "zm_cmd_closebuildmenu %i", GetSpawnIndex() ) );
+    engine->ClientCmd( VarArgs( "zm_cmd_closemenu %i", GetSpawnIndex() ) );
 
     m_iLastSpawnIndex = GetSpawnIndex();
 
@@ -148,16 +155,6 @@ void __MsgFunc_ZMBuildMenuUpdate( bf_read &msg )
 	bool active = msg.ReadOneBit() == 1;
 
 
-    pMenu->SetZombieFlags( msg.ReadByte() );
-
-    int iCosts[ZMCLASS_MAX];
-    for ( int i = 0; i < ZMCLASS_MAX; i++ )
-    {
-        iCosts[i] = msg.ReadShort();
-    }
-    pMenu->SetZombieCosts( iCosts );
-
-
     int count = msg.ReadByte();
 
 
@@ -182,8 +179,6 @@ void __MsgFunc_ZMBuildMenuUpdate( bf_read &msg )
         pMenu->Close();
 	}
 
-
-    pMenu->UpdateMenuData();
 
 	pMenu->UpdateQueue( pQueue, count );
 

--- a/mp/src/game/client/zmr/ui/zmr_buildmenu_base.h
+++ b/mp/src/game/client/zmr/ui/zmr_buildmenu_base.h
@@ -44,7 +44,7 @@ public:
     virtual int ZMKeyInput( ButtonCode_t keynum, int down );
 
     virtual void ShowMenu( C_ZMEntZombieSpawn* pSpawn );
-    virtual void UpdateMenuData() {};
+	virtual void UpdateMenu( C_ZMEntZombieSpawn* pSpawn );
     virtual void UpdateQueue( const ZMQueueSlotData_t q[], int size ) {};
 
     inline int GetLastSpawnIndex() { return m_iLastSpawnIndex; };

--- a/mp/src/game/client/zmr/ui/zmr_buildmenu_new.cpp
+++ b/mp/src/game/client/zmr/ui/zmr_buildmenu_new.cpp
@@ -113,7 +113,7 @@ void CZMBuildMenuNew::ShowPanel( bool state )
     if ( state )
     {
         // Notify the server we've opened this menu.
-        engine->ClientCmd( VarArgs( "zm_cmd_openbuildmenu %i", GetSpawnIndex() ) );
+        engine->ClientCmd( VarArgs( "zm_cmd_openmenu %i", GetSpawnIndex() ) );
     }
 
 
@@ -260,8 +260,10 @@ void CZMBuildMenuNew::ShowMenu( C_ZMEntZombieSpawn* pSpawn )
     BaseClass::ShowMenu( pSpawn );
 }
 
-void CZMBuildMenuNew::UpdateMenuData()
+void CZMBuildMenuNew::UpdateMenu( C_ZMEntZombieSpawn* pSpawn )
 {
+	BaseClass::UpdateMenu( pSpawn );
+
     if ( m_pRadial && m_pRadial->GetLastButton() && m_pRadial->GetLastButton()->GetLabel() )
     {
         UpdateButtonData( m_pRadial->GetLastButton() );

--- a/mp/src/game/client/zmr/ui/zmr_buildmenu_new.h
+++ b/mp/src/game/client/zmr/ui/zmr_buildmenu_new.h
@@ -41,7 +41,7 @@ public:
     virtual const char* GetName() OVERRIDE { return "ZMBuildMenuNew"; };
 
     virtual void ShowMenu( C_ZMEntZombieSpawn* pSpawn ) OVERRIDE;
-    virtual void UpdateMenuData() OVERRIDE;
+    virtual void UpdateMenu( C_ZMEntZombieSpawn* pSpawn ) OVERRIDE;
     virtual void UpdateQueue( const ZMQueueSlotData_t queue[], int size ) OVERRIDE;
 
 private:

--- a/mp/src/game/client/zmr/ui/zmr_manimenu.cpp
+++ b/mp/src/game/client/zmr/ui/zmr_manimenu.cpp
@@ -57,6 +57,11 @@ void CZMManiMenu::ShowPanel( bool state )
 {
     if ( IsVisible() == state ) return;
 
+    if ( state )
+    {
+        // Notify the server we've opened this menu.
+        engine->ClientCmd( VarArgs( "zm_cmd_openmenu %i", GetTrapIndex() ) );
+    }
 
     SetVisible( state );
 }

--- a/mp/src/game/client/zmr/ui/zmr_manimenu_base.cpp
+++ b/mp/src/game/client/zmr/ui/zmr_manimenu_base.cpp
@@ -31,5 +31,49 @@ void CZMManiMenuBase::ShowMenu( C_ZMEntManipulate* pMani )
     SetDescription( *pMani->GetDescription() ? pMani->GetDescription() : "Activate trap." );
     SetCost( pMani->GetCost() );
     SetTrapCost( pMani->GetTrapCost() );
+	pMani->SetMenu( this );
+
     ShowPanel( true );
 }
+
+void CZMManiMenuBase::UpdateMenu( C_ZMEntManipulate* pMani )
+{
+    SetDescription( *pMani->GetDescription() ? pMani->GetDescription() : "Activate trap." );
+    SetCost( pMani->GetCost() );
+    SetTrapCost( pMani->GetTrapCost() );
+}
+
+void CZMManiMenuBase::OnClose()
+{
+    // Notify server we've closed this menu.
+    engine->ClientCmd( VarArgs( "zm_cmd_closemenu %i", GetTrapIndex() ) );
+
+	BaseClass::OnClose();
+}
+
+void __MsgFunc_ZMManiMenuUpdate( bf_read &msg )
+{
+    if ( !g_pZMView || !g_pZMView->GetManiMenu() ) return;
+
+
+    CZMManiMenuBase* pMenu = g_pZMView->GetManiMenu();
+
+
+
+	int spawnidx = msg.ReadShort();
+
+    // We don't care about this trap since we don't have it open...
+    if ( spawnidx != pMenu->GetTrapIndex() ) return;
+
+
+	bool active = msg.ReadOneBit() == 1;
+
+
+    // No longer active, so close us.
+	if ( !active )
+	{
+        pMenu->Close();
+	}
+}
+
+USER_MESSAGE_REGISTER( ZMManiMenuUpdate );

--- a/mp/src/game/client/zmr/ui/zmr_manimenu_base.h
+++ b/mp/src/game/client/zmr/ui/zmr_manimenu_base.h
@@ -38,10 +38,12 @@ public:
 
 
     virtual void OnCommand( const char *command ) OVERRIDE;
+    virtual void OnClose() OVERRIDE;
 
 
 
     virtual void ShowMenu( C_ZMEntManipulate* pMani );
+	virtual void UpdateMenu( C_ZMEntManipulate* pSpawn );
     virtual void SetDescription( const char* ) = 0;
 
     inline int GetTrapIndex() { return m_iTrapIndex; };

--- a/mp/src/game/client/zmr/ui/zmr_manimenu_new.cpp
+++ b/mp/src/game/client/zmr/ui/zmr_manimenu_new.cpp
@@ -63,6 +63,11 @@ void CZMManiMenuNew::ShowPanel( bool state )
 {
     if ( IsVisible() == state ) return;
 
+    if ( state )
+    {
+        // Notify the server we've opened this menu.
+        engine->ClientCmd( VarArgs( "zm_cmd_openmenu %i", GetTrapIndex() ) );
+    }
 
     SetVisible( state );
 }

--- a/mp/src/game/server/npcr/npcr_nonplayer.cpp
+++ b/mp/src/game/server/npcr/npcr_nonplayer.cpp
@@ -252,9 +252,9 @@ void CNPCRNonPlayer::PostUpdate()
             else if ( bCanSee && !m_bDidSeeEnemyLastTime )
             {
                 if ( pCurEnemy->IsPlayer() )
-                    m_OnFoundPlayer.Set( m_hEnemy, this, this );
+                    m_OnFoundPlayer.Set( m_hEnemy, m_hEnemy.Get(), this );
 
-                m_OnFoundEnemy.Set( m_hEnemy, this, this );
+                m_OnFoundEnemy.Set( m_hEnemy, m_hEnemy.Get(), this );
             }
 
             m_flNextLOSOutputs = gpGlobals->curtime + 0.1f;

--- a/mp/src/game/server/zmr/npcs/zmr_shambler.cpp
+++ b/mp/src/game/server/zmr/npcs/zmr_shambler.cpp
@@ -117,6 +117,10 @@ bool CZMShambler::CanBreakObject( CBaseEntity* pEnt, bool bSwat ) const
     if ( pEnt->MyCombatCharacterPointer() != nullptr )
         return false;
 
+    // Avoid breaking our own stuff.
+    if ( pEnt->GetTeamNumber() == ZMTEAM_ZM )
+        return false;
+
     // As long as we can break it it's all good.
     return ( pEnt->GetHealth() > 0 && pEnt->m_takedamage == DAMAGE_YES );
 }

--- a/mp/src/game/server/zmr/npcs/zmr_zombiebase.cpp
+++ b/mp/src/game/server/zmr/npcs/zmr_zombiebase.cpp
@@ -254,6 +254,8 @@ CZMBaseZombie::CZMBaseZombie()
 
     m_strModelGroup = NULL_STRING;
 
+    ChangeTeam( ZMTEAM_ZM );
+
 
     g_ZombieManager.AddZombie( this );
 }
@@ -732,6 +734,10 @@ bool CZMBaseZombie::CanSwatObject( CBaseEntity* pEnt )
 bool CZMBaseZombie::CanBreakObject( CBaseEntity* pEnt, bool bSwat ) const
 {
     if ( pEnt->GetHealth() <= 0 || pEnt->m_takedamage != DAMAGE_YES )
+        return false;
+
+    // Avoid breaking our own stuff.
+    if ( pEnt->GetTeamNumber() == ZMTEAM_ZM )
         return false;
 
     CBreakable* pBreak = dynamic_cast<CBreakable*>( pEnt );

--- a/mp/src/game/server/zmr/zmr_entities.h
+++ b/mp/src/game/server/zmr/zmr_entities.h
@@ -78,6 +78,8 @@ public:
 
     bool IsActive() const { return m_bActive; }
 
+    virtual void SendMenuUpdate() = 0;
+
 private:
     bool m_bActive;
 };
@@ -140,7 +142,7 @@ public:
     void QueueClear( int inamount = -1, int inpos = -1 );
     bool CanSpawn( ZombieClass_t zclass );
 
-    void SendMenuUpdate();
+    void SendMenuUpdate() OVERRIDE;
 
     void SetRallyPoint( const Vector& pos );
 
@@ -282,10 +284,15 @@ public:
     void Spawn() OVERRIDE;
     void Precache() OVERRIDE;
 
+    bool AcceptInput( const char *szInputName, CBaseEntity *pActivator, CBaseEntity *pCaller, variant_t Value, int outputID ) OVERRIDE;
+
     void InputToggle( inputdata_t &inputdata );
     void InputHide( inputdata_t &inputdata );
     void InputUnhide( inputdata_t &inputdata );
     void InputPress( inputdata_t &inputdata );
+	void InputSetDescription( inputdata_t &inputdata ) { m_sDescription = inputdata.value.StringID(); }
+	void InputSetTrapCost( inputdata_t &inputdata );
+	void InputSetCost( inputdata_t &inputdata );
 
 
     void Trigger( CBaseEntity* pActivator );
@@ -296,6 +303,8 @@ public:
     inline int GetTriggerCount() const { return m_vTriggers.Count(); }
 
     COutputEvent m_OnPressed;
+
+	void SendMenuUpdate() OVERRIDE;
 
 
     inline const char* GetDescription() const { return m_sDescription.Get().ToCStr(); }

--- a/mp/src/game/server/zmr/zmr_player.h
+++ b/mp/src/game/server/zmr/zmr_player.h
@@ -180,23 +180,25 @@ public:
     float m_flNextResourceInc;
 
 
-    void SetBuildSpawn( CZMEntZombieSpawn* pSpawn )
+    void SetMenuEnt( CZMEntBaseUsable* pEnt )
     {
         int index = 0;
-        if ( pSpawn )
-            index = pSpawn->entindex();
+        if ( pEnt )
+            index = pEnt->entindex();
 
 
-        m_iBuildSpawnIndex = index;
+        m_iMenuEntIndex = index;
     }
 
-    void SetBuildSpawn( int index )
+    void SetMenuEnt( int index )
     {
-        m_iBuildSpawnIndex = index;
+        m_iMenuEntIndex = index;
     }
 
-    inline CZMEntZombieSpawn* GetBuildSpawn() { return dynamic_cast<CZMEntZombieSpawn*>( UTIL_EntityByIndex( m_iBuildSpawnIndex ) ); };
-    inline int GetBuildSpawnIndex() { return m_iBuildSpawnIndex; };
+    inline CZMEntZombieSpawn* GetBuildSpawn() { return dynamic_cast<CZMEntZombieSpawn*>( UTIL_EntityByIndex( m_iMenuEntIndex ) ); };
+    inline CZMEntManipulate* GetManipulate() { return dynamic_cast<CZMEntManipulate*>( UTIL_EntityByIndex( m_iMenuEntIndex ) ); };
+    inline CZMEntBaseUsable* GetMenuEnt() { return assert_cast<CZMEntBaseUsable*>( UTIL_EntityByIndex( m_iMenuEntIndex ) ); };
+    inline int GetMenuEntIndex() { return m_iMenuEntIndex; };
 
     void DeselectAllZombies();
 
@@ -287,7 +289,7 @@ private:
 
     CZMPlayerAnimState* m_pPlayerAnimState;
 
-    int m_iBuildSpawnIndex; // To update build menu.
+    int m_iMenuEntIndex; // To update build and manipulate menus.
     //Participation_t m_iParticipation;
     int m_nPickPriority;
     float m_flLastActivity;

--- a/mp/src/game/server/zmr/zmr_zm_commands.cpp
+++ b/mp/src/game/server/zmr/zmr_zm_commands.cpp
@@ -504,7 +504,7 @@ static ConCommand zm_cmd_setrally( "zm_cmd_setrally", ZM_Cmd_SetRally, "Set rall
 /*
     Open build menu
 */
-void ZM_Cmd_OpenBuildMenu( const CCommand &args )
+void ZM_Cmd_OpenMenu( const CCommand &args )
 {
     CZMPlayer* pPlayer = ToZMPlayer( UTIL_GetCommandClient() );
 
@@ -521,19 +521,19 @@ void ZM_Cmd_OpenBuildMenu( const CCommand &args )
 
 
 
-    CZMEntZombieSpawn* pSpawn = dynamic_cast<CZMEntZombieSpawn*>( UTIL_EntityByIndex( entindex ) );
+    CZMEntBaseUsable* pEntity = dynamic_cast<CZMEntBaseUsable*>( UTIL_EntityByIndex( entindex ) );
 
-    if ( pSpawn )
+    if ( pEntity )
     {
-        pPlayer->SetBuildSpawn( pSpawn );
-        pSpawn->SendMenuUpdate();
+        pPlayer->SetMenuEnt( pEntity );
+        pEntity->SendMenuUpdate();
     }
 }
 
-static ConCommand zm_cmd_openbuildmenu( "zm_cmd_openbuildmenu", ZM_Cmd_OpenBuildMenu, "", FCVAR_HIDDEN );
+static ConCommand zm_cmd_openmenu( "zm_cmd_openmenu", ZM_Cmd_OpenMenu, "", FCVAR_HIDDEN );
 
 
-void ZM_Cmd_CloseBuildMenu( const CCommand &args )
+void ZM_Cmd_CloseMenu( const CCommand &args )
 {
     CZMPlayer* pPlayer = ToZMPlayer( UTIL_GetCommandClient() );
 
@@ -542,10 +542,10 @@ void ZM_Cmd_CloseBuildMenu( const CCommand &args )
     if ( !pPlayer->IsZM() ) return;
 
 
-    pPlayer->SetBuildSpawn( 0 );
+    pPlayer->SetMenuEnt( 0 );
 }
 
-static ConCommand zm_cmd_closebuildmenu( "zm_cmd_closebuildmenu", ZM_Cmd_CloseBuildMenu, "", FCVAR_HIDDEN );
+static ConCommand zm_cmd_closemenu( "zm_cmd_closemenu", ZM_Cmd_CloseMenu, "", FCVAR_HIDDEN );
 
 
 /*

--- a/mp/src/game/shared/zmr/zmr_usermsgs.cpp
+++ b/mp/src/game/shared/zmr/zmr_usermsgs.cpp
@@ -13,6 +13,7 @@
 void RegisterZMUserMessages( void )
 {
     usermessages->Register( "ZMBuildMenuUpdate", -1 ); // 1 * spawn ehandle, 5 * queue bytes
+	usermessages->Register( "ZMManiMenuUpdate", -1 );
 
 
     usermessages->Register( "ZMObjDisplay", -1 );


### PR DESCRIPTION
A few more changes that add onto the previous mapping improvements PR (https://github.com/zm-reborn/zmr-game/pull/284).

- Implemented 3 new inputs on `info_manipulate` which change its properties mid-game.
- Overhauled menu updating code so `info_manipulate` menus are properly updated and hidden.
- Made `OnFoundEnemy/Player` outputs on non-player NPCRs use the enemy as the activator instead of itself.
- Finished support for zombies refusing to attack objects on the ZM team and added groundwork for similar team behavior in the future.

---

The new `info_manipulate` inputs are `SetDescription`, `SetCost`, and `SetTrapCost`, which change the trap's description, cost, and trap override cost respectively. If the ZM already has the menu open, it will properly update when the `info_manipulate` receives these inputs.

<p align="center">
<img src="https://i.imgur.com/4rx09t5.png" width="512"/>
</p>

As part of these changes, the existing `info_zombiespawn` updating code has been overhauled to be capable of using other menus, rather than just build menus. This was done so `info_manipulate` properly updates when it's changed or hidden while the ZM already has the menu open.

---

In most Source games, the `OnFoundEnemy/Player` outputs on NPCs don't pass the enemy as the activator, only passing it as the parameter. This makes it nearly impossible for mappers to access a pointer to the enemy outside of `func_tank`'s `SetTargetEntity` and other inputs that take the parameter directly.

The outputs for non-player NPCRs in ZM:R appears to have been taken from the same code, so I changed it to use the enemy as the activator instead of itself. This means existing maps that use `OnFoundEnemy > !activator` will use the enemy as the activator instead of the existing behavior that passes the entity firing the output as the activator, but I assume very few ZM maps use that output on NPCs to begin with and the few that do most likely do not use `!activator` specifically to refer to the NPC itself.

---

This PR finishes the team stuff from the previous PR which prevents zombies from attacking objects assigned to the ZM team. Team number has also been added to the FGD for breakable entities (e.g. `func_breakable`), which allows it to come into official use in maps and lays groundwork for other team-based behavior in the future.

The picture below shows team number being used in an experimental map where zombies spawn on a `func_breakable` airship. When the ZM orders zombies to another point on the airship, the zombies think it's an order to break the `func_breakable` and attempt to travel to the center of the airship to destroy it, even though it has a damage filter that prevents them from doing so. When the airship is on the ZM team, however, zombies will no longer attack the airship and instead treat clicks as move orders.

<p align="center">
<img src="https://i.imgur.com/mpij2qy.jpg" width="768"/>
</p>

This is still a very specific feature that I don't expect to be used often, but it could be used on other breakable objects essential to the ZM which zombies could attack by accident.

---

The menu updating changes brought on by `info_manipulate` are the largest and probably the riskiest changes out of all of these, but basic testing hasn't yielded any problems. I also didn't bring on much warning before opening this PR, so I understand if this needs to stay under review for a while.

I don't currently have any other contribution plans, although I don't expect this to be my last.